### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/libraries/resultsdbpy/resultsdbpy/controller/test_controller_unittest.py
+++ b/libraries/resultsdbpy/resultsdbpy/controller/test_controller_unittest.py
@@ -60,7 +60,7 @@ class TestControllerTest(FlaskTestCase, WaitForDockerTestCase):
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     @FlaskTestCase.run_with_webserver()
-    def test_list_all(self, client, **kwargs):
+    def test_list_all_two(self, client, **kwargs):
         response = client.get(self.URL + '/api/layout-tests/tests?limit=2')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), [


### PR DESCRIPTION
These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

More details [here](https://codereview.doctor/features/python/best-practice/avoid-duplicate-unit-test-names).